### PR TITLE
Added prefix and suffix option for SGit()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Create a session with name. Session will be automatically tracked.
 Like :*Session* but use current repository name and branch to create the
 name.  i.e.  (`repository@branch`.)
 
+If the `vim-ctrlp-session.session-prefix` (respectively
+`vim-ctrlp-session.session-suffix`) git configuration are set, its value is
+automatically prefixed (respectively suffixed) to the `repository` name.
+
+This is useful when you have several checkouts of the same repository (with the
+same name) at different location and you want to be able to distinguish those.
+
 **Requires** [Tpope/vim-fugitive] (https://github.com/tpope/vim-fugitive)
 
 ### `:SLoad {name}`

--- a/autoload/ctrlp_session.vim
+++ b/autoload/ctrlp_session.vim
@@ -42,6 +42,32 @@ function! ctrlp_session#create(name)
 endfunction
 "}}}
 
+" Load the session prefix from git. {{{
+function! ctrlp_session#read_session_prefix_from_git()
+	let l:session_prefix = system('git config vim-ctrlp-session.session-prefix')
+
+	if v:shell_error
+		throw "Unable to read session prefix. Git not available or session-prefix not set."
+	endif
+
+	" Return the stripped result.
+	return substitute(l:session_prefix, '^\s*\(.\{-}\)[\s\r\n]*$', '\1', '')
+endfunction
+" }}}
+
+" Load the session suffix from git. {{{
+function! ctrlp_session#read_session_suffix_from_git()
+	let l:session_suffix = system('git config vim-ctrlp-session.session-suffix')
+
+	if v:shell_error
+		throw "Unable to read session suffix. Git not available or session-suffix not set."
+	endif
+
+	" Return the stripped result.
+	return substitute(l:session_suffix, '^\s*\(.\{-}\)[\s\r\n]*$', '\1', '')
+endfunction
+" }}}
+
 " Create a session using name of current git branch. {{{
 function! ctrlp_session#create_git()
 	if !exists("*fugitive#head")
@@ -50,14 +76,30 @@ function! ctrlp_session#create_git()
         echohl None
 		return
 	endif
+
 	if empty(fugitive#head())
         echohl WarningMsg
 		echomsg "Cannot create session: No git repository found."
         echohl None
 		return
-    endif
+	endif
+
     let l:repository=fnamemodify(s:system("git rev-parse --show-toplevel"), ":t")
-    let l:name=l:repository."@".fugitive#head()
+
+	try
+		let l:session_prefix = ctrlp_session#read_session_prefix_from_git()
+	catch /^Unable to read session prefix/
+		let l:session_prefix = ''
+	endtry
+
+	try
+		let l:session_suffix = ctrlp_session#read_session_suffix_from_git()
+	catch /^Unable to read session suffix/
+		let l:session_suffix = ''
+	endtry
+
+	let l:name=l:session_prefix.l:repository.l:session_suffix."@".fugitive#head()
+
     call ctrlp_session#create(l:name)
 endfunction
 "}}}

--- a/doc/ctlrp_session.txt
+++ b/doc/ctlrp_session.txt
@@ -50,6 +50,13 @@ COMMANDS                                            *ctrlp_session-commands*
                         and branch to create the name.  i.e.
                         (`repository@branch`.)
 
+                        <repository> can be automatically prefixed and/or
+                        suffixed by setting the following configuration values
+                        in Git's configuration:
+
+                        - vim-ctrlp-session.session-prefix
+                        - vim-ctrlp-session.session-suffix
+
                         ** Requires 'Tpope/vim-fugitive' Vim plugin **
 
                                                 *ctrlp_session-:SLoad*


### PR DESCRIPTION
Added a prefix/suffix option support for `SGit()` as it can be useful when one has different checkouts of the same repository at different locations and wants to distinguish between those.
