### PR TITLE
Mkdirp

### DIFF
--- a/autoload/ctrlp_session.vim
+++ b/autoload/ctrlp_session.vim
@@ -33,7 +33,15 @@ function! s:system(cmd)
     return l:lines[0]
 endfunction
 " }}}
-"
+
+" mkdirp {{{
+function! s:Mkdirp(dirname)
+  if !isdirectory(expand(a:dirname))
+    call mkdir(expand(a:dirname), 'p')
+  endif
+endfunction
+" }}}
+
 " Create a session {{{
 function! ctrlp_session#create(name)
     echo 'Tracking session '.a:name
@@ -168,6 +176,7 @@ function! ctrlp_session#persist()
     let sessionoptions= &sessionoptions
     try
       set sessionoptions-=blank sessionoptions-=options
+      call s:Mkdirp(fnamemodify(g:this_ctrlp_session, ':p:h'))
       execute 'mksession! '.fnameescape(g:this_ctrlp_session)
       call writefile(insert(readfile(g:this_ctrlp_session), 'let g:this_ctrlp_session =v:this_session', -2), g:this_ctrlp_session)
     catch

--- a/doc/ctlrp_session.txt
+++ b/doc/ctlrp_session.txt
@@ -95,7 +95,8 @@ Once inside CtrlP prompt:~
 GLOBAL OPTIONS                                   *ctrlp_session-global-options*
 
                                                         *'ctrlp_session_path'*
-default: '~/.vim_sessions'
+default: g:ctrlp_cache_dir . '/sessions' if g:ctrlp_cache_dir exists
+         else '~/.vim_sessions'
 
 Control where the session files will be persisted on disk.
 

--- a/plugin/ctrlp_session.vim
+++ b/plugin/ctrlp_session.vim
@@ -4,7 +4,11 @@
 
 " Location of session files
 if !exists('g:ctrlp_session_path')
-	let g:ctrlp_session_path="~/.vim_sessions"
+	if exists('g:ctrlp_cache_dir')
+		let g:ctrlp_session_path=expand(g:ctrlp_cache_dir . '/sessions')
+	else
+		let g:ctrlp_session_path="~/.vim_sessions"
+	endif
 endif
 
 augroup ctrlp_session


### PR DESCRIPTION
- fixes #8 i.e. auto create directory if not exist.
- prefer `g:ctrlp_cache_dir . '/sessions'` over `~/.vim_sessions`. This could have impact on existing users.
