### PR TITLE
auto-create directory if not exist when persisting session

### DIFF
--- a/autoload/ctrlp_session.vim
+++ b/autoload/ctrlp_session.vim
@@ -168,6 +168,7 @@ function! ctrlp_session#persist()
     let sessionoptions= &sessionoptions
     try
       set sessionoptions-=blank sessionoptions-=options
+      call s:Mkdirp(fnamemodify(g:this_ctrlp_session, ':p:h'))
       execute 'mksession! '.fnameescape(g:this_ctrlp_session)
       call writefile(insert(readfile(g:this_ctrlp_session), 'let g:this_ctrlp_session =v:this_session', -2), g:this_ctrlp_session)
     catch
@@ -180,3 +181,11 @@ function! ctrlp_session#persist()
   return ''
 endfunction
 "}}}
+
+" mkdirp {{{
+function! s:Mkdirp(dirname)
+  if !isdirectory(expand(a:dirname))
+    call mkdir(expand(a:dirname), 'p')
+  endif
+endfunction
+" }}}


### PR DESCRIPTION
fixes #8 i.e. auto create directory if not exist.

Apprently the load order of plugins can be different so removed dependency on `g:ctrlp_cache_dir` which I was using in https://github.com/okcompute/vim-ctrlp-session/pull/10